### PR TITLE
feat: add opt-in auth for temp deploys

### DIFF
--- a/.github/workflows/temp-deploy.yaml
+++ b/.github/workflows/temp-deploy.yaml
@@ -20,6 +20,10 @@ on:
         type: string
         required: true
         description: "Image tag (e.g., abc1234)"
+      auth-middleware:
+        type: string
+        default: ""
+        description: "Optional Traefik middleware for temp routers (e.g., oauth2-admin@file)"
     secrets:
       GH_TOKEN:
         required: true
@@ -87,6 +91,7 @@ jobs:
             --tag "${{ inputs.tag }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
             --repo-owner "${{ github.repository_owner }}" \
+            --auth-middleware "${{ inputs.auth-middleware }}" \
             --app-repo-path .app-repo
 
       - name: Commit and push

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ App repo builds image to ghcr.io
 ## Workflows
 
 - `deploy.yaml` updates a production image tag in home-ops, pinned to the image digest.
-- `temp-deploy.yaml` creates temporary PR environments.
+- `temp-deploy.yaml` creates temporary PR environments, with optional Traefik auth.
 - `temp-cleanup.yaml` removes temporary PR environments.
 
 ## Use

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,7 +6,7 @@
 |----------|---------|-------------|
 | `ci.yml` | Push, PR, tag `v*` | Runs tests; on tag, generates a changelog and creates a GitHub Release |
 | `deploy.yaml` | Push to main | Updates the digest-pinned image tag in home-ops and creates a GitHub Deployment |
-| `temp-deploy.yaml` | PR labeled `temp-deploy` or new commits | Creates a temporary PR environment |
+| `temp-deploy.yaml` | PR labeled `temp-deploy` or new commits | Creates a temporary PR environment; `auth-middleware` can protect temp routers |
 | `temp-cleanup.yaml` | PR closed or label removed | Removes a temporary PR environment |
 
 ## Scripts
@@ -16,7 +16,7 @@ Node.js 26 ESM scripts. YAML parsing uses `js-yaml`.
 | Script | Used by | Description |
 |--------|---------|-------------|
 | `src/update-tag.js` | `deploy.yaml` | Updates a `ghcr.io` image tag in a compose file, pinned to the digest |
-| `src/temp-compose.js` | `temp-deploy.yaml` | Builds the temp deploy compose file |
+| `src/temp-compose.js` | `temp-deploy.yaml` | Builds the temp deploy compose file, including optional auth middleware rewrites |
 | `src/deployment.js` | `temp-deploy.yaml`, `temp-cleanup.yaml` | Creates or cleans up GitHub Deployments for PR environments |
 | `src/temp-cleanup.js` | `temp-cleanup.yaml` | Removes the temp deploy app directory |
 | `src/git-push.js` | all deploy workflows | Commits and pushes with retry on conflict |

--- a/docs/temp-deploy.md
+++ b/docs/temp-deploy.md
@@ -94,6 +94,8 @@ jobs:
       app-path: apps/your-app
       service-name: your-app
       tag: ${{ needs.temp-build.outputs.tag }}
+      # Optional: protect the temp PR site with Traefik auth.
+      # auth-middleware: oauth2-admin@file
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -118,6 +120,7 @@ jobs:
 - service set: keeps `service-name` plus recursive `depends_on` services
 - image tag: updates only `ghcr.io/<owner>/*` images
 - Traefik labels: rewrites router/service names and hostname
+- optional auth: replaces/adds router middleware labels when `auth-middleware` is set
 - volumes: converts bind mounts to named Docker volumes
 - networks/volumes: removes unused top-level declarations
 - `container_name`: strips names to avoid conflicts
@@ -146,6 +149,20 @@ git commit -m "add temp deploy env overrides"
 The workflow copies `.env.sops` into the temp stack as `.env.sops.override`.
 docker-cd merges it over the home-ops base `.env.sops`.
 
+## Optional Auth
+
+Set `auth-middleware` to protect a temp PR site with an existing Traefik middleware:
+
+```yaml
+with:
+  app-path: apps/bang
+  service-name: bang
+  tag: ${{ needs.temp-build.outputs.tag }}
+  auth-middleware: oauth2-admin@file
+```
+
+If omitted, temp deploys keep the production middleware labels.
+
 ## Inputs
 
 ### Temp Deploy
@@ -156,6 +173,7 @@ docker-cd merges it over the home-ops base `.env.sops`.
 | `app-path` | Yes | - | Base app path, like `apps/bang` |
 | `service-name` | Yes | - | Compose service to deploy, like `bang` |
 | `tag` | Yes | - | Image tag |
+| `auth-middleware` | No | empty | Optional Traefik middleware for temp routers, like `oauth2-admin@file` |
 
 ### Temp Cleanup
 

--- a/src/temp-compose.js
+++ b/src/temp-compose.js
@@ -113,8 +113,37 @@ function pruneVolumes(doc, volumeNames, messages) {
 	}
 }
 
+function applyAuthMiddleware(labels, authMiddleware) {
+	const middleware = authMiddleware?.trim();
+	if (!middleware) return labels;
+
+	const routerNames = new Set();
+	const routersWithMiddleware = new Set();
+
+	const rewritten = labels.map((label) => {
+		const router = label.match(/^traefik\.http\.routers\.([^.]+)\./)?.[1];
+		if (!router) return label;
+
+		routerNames.add(router);
+		if (!label.startsWith(`traefik.http.routers.${router}.middlewares=`)) {
+			return label;
+		}
+
+		routersWithMiddleware.add(router);
+		return `traefik.http.routers.${router}.middlewares=${middleware}`;
+	});
+
+	for (const router of routerNames) {
+		if (!routersWithMiddleware.has(router)) {
+			rewritten.push(`traefik.http.routers.${router}.middlewares=${middleware}`);
+		}
+	}
+
+	return rewritten;
+}
+
 export function rewriteComposeForTempDeploy(doc, options) {
-	const { appName, serviceName, tag, prNumber, repoOwner } = options;
+	const { appName, serviceName, tag, prNumber, repoOwner, authMiddleware } = options;
 	const rewritten = structuredClone(doc);
 	const messages = [];
 	const tempName = `${serviceName}-pr-${prNumber}`;
@@ -151,7 +180,7 @@ export function rewriteComposeForTempDeploy(doc, options) {
 		}
 
 		if (service.labels) {
-			service.labels = service.labels
+			const labels = service.labels
 				.filter((label) => !label.includes('redirect'))
 				.map((label) =>
 					label
@@ -159,6 +188,7 @@ export function rewriteComposeForTempDeploy(doc, options) {
 						.replaceAll(`traefik.http.services.${serviceName}`, `traefik.http.services.${tempName}`)
 						.replace(/Host\(`[^`]+`\)/g, `Host(\`${hostname}\`)`),
 				);
+			service.labels = applyAuthMiddleware(labels, authMiddleware);
 		}
 
 		if (service.volumes) {
@@ -209,6 +239,7 @@ export async function main(argv = process.argv.slice(2)) {
 			'pr-number': { type: 'string' },
 			'repo-owner': { type: 'string' },
 			'app-repo-path': { type: 'string' },
+			'auth-middleware': { type: 'string' },
 		},
 	});
 	for (const key of ['app-path', 'service-name', 'tag', 'pr-number', 'repo-owner']) {
@@ -220,6 +251,7 @@ export async function main(argv = process.argv.slice(2)) {
 	const tag = args['tag'];
 	const prNumber = args['pr-number'];
 	const repoOwner = args['repo-owner'];
+	const authMiddleware = args['auth-middleware'];
 	const appName = path.basename(appPath);
 	const tempPath = `${appPath}-pr-${prNumber}`;
 
@@ -236,7 +268,7 @@ export async function main(argv = process.argv.slice(2)) {
 
 	const composePath = path.join(tempPath, 'docker-compose.yml');
 	const doc = yaml.load(fs.readFileSync(composePath, 'utf8'));
-	const result = rewriteComposeForTempDeploy(doc, { appName, serviceName, tag, prNumber, repoOwner });
+	const result = rewriteComposeForTempDeploy(doc, { appName, serviceName, tag, prNumber, repoOwner, authMiddleware });
 	for (const message of result.messages) {
 		console.log(message);
 	}

--- a/src/temp-compose.test.js
+++ b/src/temp-compose.test.js
@@ -199,6 +199,167 @@ describe('temp-compose', () => {
 		assert.strictEqual(result.url, 'https://pr-42-example.jaw.dev');
 	});
 
+	it('preserves existing middlewares by default', () => {
+		const result = rewriteComposeForTempDeploy(
+			{
+				services: {
+					bang: {
+						image: 'ghcr.io/wajeht/bang:old',
+						labels: [
+							'traefik.http.routers.bang.rule=Host(`bang.jaw.dev`)',
+							'traefik.http.routers.bang.entrypoints=websecure',
+							'traefik.http.routers.bang.middlewares=rate-limit-global@file',
+							'traefik.http.services.bang.loadbalancer.server.port=80',
+						],
+					},
+				},
+			},
+			{
+				appName: 'bang',
+				serviceName: 'bang',
+				tag: 'abc1234',
+				prNumber: '42',
+				repoOwner: 'wajeht',
+			},
+		);
+
+		assert.deepStrictEqual(result.doc.services.bang.labels, [
+			'traefik.http.routers.bang-pr-42.rule=Host(`pr-42-bang.jaw.dev`)',
+			'traefik.http.routers.bang-pr-42.entrypoints=websecure',
+			'traefik.http.routers.bang-pr-42.middlewares=rate-limit-global@file',
+			'traefik.http.services.bang-pr-42.loadbalancer.server.port=80',
+		]);
+	});
+
+	it('replaces existing router middlewares when auth-middleware is set', () => {
+		const result = rewriteComposeForTempDeploy(
+			{
+				services: {
+					bang: {
+						image: 'ghcr.io/wajeht/bang:old',
+						labels: [
+							'traefik.http.routers.bang.rule=Host(`bang.jaw.dev`)',
+							'traefik.http.routers.bang.entrypoints=websecure',
+							'traefik.http.routers.bang.middlewares=rate-limit-global@file',
+							'traefik.http.services.bang.loadbalancer.server.port=80',
+						],
+					},
+				},
+			},
+			{
+				appName: 'bang',
+				serviceName: 'bang',
+				tag: 'abc1234',
+				prNumber: '42',
+				repoOwner: 'wajeht',
+				authMiddleware: 'oauth2-admin@file',
+			},
+		);
+
+		assert.deepStrictEqual(result.doc.services.bang.labels, [
+			'traefik.http.routers.bang-pr-42.rule=Host(`pr-42-bang.jaw.dev`)',
+			'traefik.http.routers.bang-pr-42.entrypoints=websecure',
+			'traefik.http.routers.bang-pr-42.middlewares=oauth2-admin@file',
+			'traefik.http.services.bang-pr-42.loadbalancer.server.port=80',
+		]);
+	});
+
+	it('adds router middlewares when auth-middleware is set and no middleware label exists', () => {
+		const result = rewriteComposeForTempDeploy(
+			{
+				services: {
+					demo: {
+						image: 'ghcr.io/wajeht/demo:old',
+						labels: [
+							'traefik.http.routers.demo.rule=Host(`demo.jaw.dev`)',
+							'traefik.http.routers.demo.entrypoints=websecure',
+							'traefik.http.services.demo.loadbalancer.server.port=3000',
+						],
+					},
+				},
+			},
+			{
+				appName: 'demo',
+				serviceName: 'demo',
+				tag: 'abc1234',
+				prNumber: '42',
+				repoOwner: 'wajeht',
+				authMiddleware: 'oauth2-admin@file',
+			},
+		);
+
+		assert.deepStrictEqual(result.doc.services.demo.labels, [
+			'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)',
+			'traefik.http.routers.demo-pr-42.entrypoints=websecure',
+			'traefik.http.services.demo-pr-42.loadbalancer.server.port=3000',
+			'traefik.http.routers.demo-pr-42.middlewares=oauth2-admin@file',
+		]);
+	});
+
+	it('applies auth-middleware to each rewritten router on the service', () => {
+		const result = rewriteComposeForTempDeploy(
+			{
+				services: {
+					homeassistant: {
+						image: 'ghcr.io/wajeht/homeassistant:old',
+						labels: [
+							'traefik.http.routers.homeassistant.rule=Host(`ha.jaw.dev`)',
+							'traefik.http.routers.homeassistant.middlewares=oauth2-admin@file',
+							'traefik.http.routers.homeassistant-app.rule=Host(`ha-app.jaw.dev`)',
+							'traefik.http.routers.homeassistant-app.middlewares=rate-limit-global@file',
+							'traefik.http.services.homeassistant.loadbalancer.server.port=8123',
+						],
+					},
+				},
+			},
+			{
+				appName: 'homeassistant',
+				serviceName: 'homeassistant',
+				tag: 'abc1234',
+				prNumber: '42',
+				repoOwner: 'wajeht',
+				authMiddleware: 'oauth2-admin@file',
+			},
+		);
+
+		assert.deepStrictEqual(result.doc.services.homeassistant.labels, [
+			'traefik.http.routers.homeassistant-pr-42.rule=Host(`pr-42-homeassistant.jaw.dev`)',
+			'traefik.http.routers.homeassistant-pr-42.middlewares=oauth2-admin@file',
+			'traefik.http.routers.homeassistant-pr-42-app.rule=Host(`pr-42-homeassistant.jaw.dev`)',
+			'traefik.http.routers.homeassistant-pr-42-app.middlewares=oauth2-admin@file',
+			'traefik.http.services.homeassistant-pr-42.loadbalancer.server.port=8123',
+		]);
+	});
+
+	it('ignores blank auth-middleware values', () => {
+		const result = rewriteComposeForTempDeploy(
+			{
+				services: {
+					bang: {
+						image: 'ghcr.io/wajeht/bang:old',
+						labels: [
+							'traefik.http.routers.bang.rule=Host(`bang.jaw.dev`)',
+							'traefik.http.routers.bang.middlewares=rate-limit-global@file',
+						],
+					},
+				},
+			},
+			{
+				appName: 'bang',
+				serviceName: 'bang',
+				tag: 'abc1234',
+				prNumber: '42',
+				repoOwner: 'wajeht',
+				authMiddleware: '   ',
+			},
+		);
+
+		assert.deepStrictEqual(result.doc.services.bang.labels, [
+			'traefik.http.routers.bang-pr-42.rule=Host(`pr-42-bang.jaw.dev`)',
+			'traefik.http.routers.bang-pr-42.middlewares=rate-limit-global@file',
+		]);
+	});
+
 	it('fails when service-name is not present', () => {
 		assert.throws(
 			() =>
@@ -284,6 +445,57 @@ describe('temp-compose', () => {
 			assert.deepStrictEqual(Object.keys(rewritten.networks).sort(), ['internal', 'traefik']);
 			assert.deepStrictEqual(Object.keys(rewritten.volumes), ['db']);
 			assert.strictEqual(rewritten.services.demo.labels[1], 'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)');
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('passes auth-middleware through the CLI', () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-cd-deploy-workflow-'));
+		const appPath = path.join(tempDir, 'apps', 'demo');
+		const tempPath = `${appPath}-pr-42`;
+
+		try {
+			fs.mkdirSync(appPath, { recursive: true });
+			fs.writeFileSync(
+				path.join(appPath, 'docker-compose.yml'),
+				yaml.dump({
+					services: {
+						demo: {
+							image: 'ghcr.io/wajeht/demo:old',
+							labels: [
+								'traefik.http.routers.demo.rule=Host(`demo.jaw.dev`)',
+								'traefik.http.routers.demo.middlewares=rate-limit-global@file',
+								'traefik.http.services.demo.loadbalancer.server.port=3000',
+							],
+						},
+					},
+				}),
+			);
+
+			execFileSync('node', [
+				scriptPath,
+				'--app-path',
+				appPath,
+				'--service-name',
+				'demo',
+				'--tag',
+				'abc1234',
+				'--pr-number',
+				'42',
+				'--repo-owner',
+				'wajeht',
+				'--auth-middleware',
+				'oauth2-admin@file',
+			]);
+
+			const rewritten = yaml.load(fs.readFileSync(path.join(tempPath, 'docker-compose.yml'), 'utf8'));
+
+			assert.deepStrictEqual(rewritten.services.demo.labels, [
+				'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)',
+				'traefik.http.routers.demo-pr-42.middlewares=oauth2-admin@file',
+				'traefik.http.services.demo-pr-42.loadbalancer.server.port=3000',
+			]);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- add optional temp deploy auth-middleware input
- pass auth middleware through to temp compose rewrites
- document opt-in usage for Traefik auth

## Tests
- npm test
- workflow YAML parse