### PR TITLE
chore: update docker-cd workflow to v0.0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ App repo builds image to ghcr.io
 ```yaml
 jobs:
   deploy:
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.26
     with:
       app-path: apps/your-app
       service-name: your-app

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,7 +7,7 @@
 ```yaml
 jobs:
   deploy:
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.26
     with:
       app-path: apps/your-app
       service-name: your-app
@@ -21,7 +21,7 @@ With a custom URL:
 ```yaml
 jobs:
   deploy:
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.26
     with:
       app-path: apps/close-powerlifting
       service-name: close-powerlifting


### PR DESCRIPTION
Updates pinned `wajeht/docker-cd-deploy-workflow` references to `v0.0.26`.

This picks up the temp deploy change that writes `x-docker-cd` config into the generated compose file instead of creating `docker-cd.yml`.