### PR TITLE
chore: convert workflow scripts to TypeScript

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Update image tag
         run: |
-          node .deploy-workflow/src/update-tag.js \
+          node .deploy-workflow/src/update-tag.ts \
             --app-path "${{ inputs.app-path }}" \
             --service-name "${{ inputs.service-name }}" \
             --tag "${{ inputs.tag }}" \
@@ -78,7 +78,7 @@ jobs:
 
       - name: Commit and push
         run: |
-          node .deploy-workflow/src/git-push.js \
+          node .deploy-workflow/src/git-push.ts \
             --paths "${{ inputs.app-path }}/docker-compose.yml" \
             --message "chore(${{ github.event.repository.name }}): update to ${{ inputs.tag }}"
 

--- a/.github/workflows/temp-cleanup.yaml
+++ b/.github/workflows/temp-cleanup.yaml
@@ -46,19 +46,19 @@ jobs:
 
       - name: Remove temp stack
         run: |
-          node .deploy-workflow/src/temp-cleanup.js \
+          node .deploy-workflow/src/temp-cleanup.ts \
             --app-path "${{ inputs.app-path }}" \
             --pr-number "${{ github.event.pull_request.number }}"
 
       - name: Commit and push
         run: |
-          node .deploy-workflow/src/git-push.js \
+          node .deploy-workflow/src/git-push.ts \
             --paths "${{ inputs.app-path }}-pr-${{ github.event.pull_request.number }}" \
             --message "chore(${{ github.event.repository.name }}): remove temp deploy pr-${{ github.event.pull_request.number }}"
 
       - name: Cleanup GitHub deployment
         run: |
-          node .deploy-workflow/src/deployment.js \
+          node .deploy-workflow/src/deployment.ts \
             --action cleanup \
             --token "${{ github.token }}" \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/temp-deploy.yaml
+++ b/.github/workflows/temp-deploy.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Request deployment
         id: deployment
         run: |
-          node .deploy-workflow/src/deployment.js \
+          node .deploy-workflow/src/deployment.ts \
             --action request \
             --token "${{ github.token }}" \
             --repo "${{ github.repository }}" \
@@ -85,7 +85,7 @@ jobs:
       - name: Rewrite compose for temp deploy
         id: rewrite
         run: |
-          node .deploy-workflow/src/temp-compose.js \
+          node .deploy-workflow/src/temp-compose.ts \
             --app-path "${{ inputs.app-path }}" \
             --service-name "${{ inputs.service-name }}" \
             --tag "${{ inputs.tag }}" \
@@ -96,13 +96,13 @@ jobs:
 
       - name: Commit and push
         run: |
-          node .deploy-workflow/src/git-push.js \
+          node .deploy-workflow/src/git-push.ts \
             --paths "${{ inputs.app-path }}-pr-${{ github.event.pull_request.number }}" \
             --message "chore(${{ github.event.repository.name }}): temp deploy pr-${{ github.event.pull_request.number }} @ ${{ inputs.tag }}"
 
       - name: Mark deployment success
         run: |
-          node .deploy-workflow/src/deployment.js \
+          node .deploy-workflow/src/deployment.ts \
             --action deploy \
             --token "${{ github.token }}" \
             --repo "${{ github.repository }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 built
 dist
+*.tsbuildinfo
 node_modules
 CLAUDE.md
 .claude

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,15 +11,16 @@
 
 ## Scripts
 
-Node.js 26 ESM scripts. YAML parsing uses `js-yaml`.
+Node.js 26 ESM TypeScript scripts. YAML parsing uses `js-yaml`.
+Run `npm test` for typecheck plus tests. Run `npm run build` to compile scripts into `dist/`.
 
 | Script | Used by | Description |
 |--------|---------|-------------|
-| `src/update-tag.js` | `deploy.yaml` | Updates a `ghcr.io` image tag in a compose file, pinned to the digest |
-| `src/temp-compose.js` | `temp-deploy.yaml` | Builds the temp deploy compose file, including optional auth middleware rewrites |
-| `src/deployment.js` | `temp-deploy.yaml`, `temp-cleanup.yaml` | Creates or cleans up GitHub Deployments for PR environments |
-| `src/temp-cleanup.js` | `temp-cleanup.yaml` | Removes the temp deploy app directory |
-| `src/git-push.js` | all deploy workflows | Commits and pushes with retry on conflict |
+| `src/update-tag.ts` | `deploy.yaml` | Updates a `ghcr.io` image tag in a compose file, pinned to the digest |
+| `src/temp-compose.ts` | `temp-deploy.yaml` | Builds the temp deploy compose file, including optional auth middleware rewrites |
+| `src/deployment.ts` | `temp-deploy.yaml`, `temp-cleanup.yaml` | Creates or cleans up GitHub Deployments for PR environments |
+| `src/temp-cleanup.ts` | `temp-cleanup.yaml` | Removes the temp deploy app directory |
+| `src/git-push.ts` | all deploy workflows | Commits and pushes with retry on conflict |
 
 ## Secrets
 

--- a/docs/temp-deploy.md
+++ b/docs/temp-deploy.md
@@ -154,7 +154,7 @@ jobs:
 
 ## What Gets Rewritten
 
-`src/temp-compose.js` copies the prod app directory and changes:
+`src/temp-compose.ts` copies the prod app directory and changes:
 
 - service set: keeps `service-name` plus recursive `depends_on` services
 - image tag: updates only `ghcr.io/<owner>/*` images

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,28 @@
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^26.0.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/argparse": {
@@ -39,6 +61,27 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Reusable GitHub Actions workflow for instant Docker deploys. When an app repo pushes a tag, this workflow updates the image tag in your home-ops repo, triggering docker-cd to deploy.",
   "type": "module",
   "scripts": {
-    "test": "node --test src/*.test.js"
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && node --test src/*.test.ts"
   },
   "repository": {
     "type": "git",
@@ -19,5 +21,10 @@
   "homepage": "https://github.com/wajeht/docker-cd-deploy-workflow#readme",
   "dependencies": {
     "js-yaml": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^26.0.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/src/deployment.test.ts
+++ b/src/deployment.test.ts
@@ -1,18 +1,35 @@
-import { describe, it } from 'node:test';
+import { describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { main } from './deployment.js';
+import { main } from './deployment.ts';
 
-function fakeFetch(responses) {
-	const calls = [];
-	async function fetch(url, options = {}) {
+type FakeResponse = {
+	ok?: boolean;
+	status?: number;
+	json?: unknown;
+	text?: string;
+};
+
+type FetchCall = {
+	url: string | URL | Request;
+	method: string;
+	body: unknown;
+};
+
+type FakeFetch = ((url: string | URL | Request, options?: RequestInit) => Promise<Response>) & {
+	calls: FetchCall[];
+};
+
+function fakeFetch(responses: FakeResponse[]): FakeFetch {
+	const calls: FetchCall[] = [];
+	async function fetchMock(url: string | URL | Request, options: RequestInit = {}) {
 		const response = responses.shift() || {};
 		calls.push({
 			url,
 			method: options.method || 'GET',
-			body: options.body ? JSON.parse(options.body) : null,
+			body: typeof options.body === 'string' ? JSON.parse(options.body) : null,
 		});
 		return {
 			ok: response.ok ?? true,
@@ -23,21 +40,21 @@ function fakeFetch(responses) {
 			async text() {
 				return response.text ?? '';
 			},
-		};
+		} as Response;
 	}
-	fetch.calls = calls;
-	return fetch;
+	fetchMock.calls = calls;
+	return fetchMock;
 }
 
-function withFetch(t, fetch) {
+function withFetch(t: TestContext, fetchMock: FakeFetch): void {
 	const previous = globalThis.fetch;
-	globalThis.fetch = fetch;
+	globalThis.fetch = fetchMock;
 	t.after(() => {
 		globalThis.fetch = previous;
 	});
 }
 
-function withGithubOutput(t) {
+function withGithubOutput(t: TestContext): string {
 	const previous = process.env.GITHUB_OUTPUT;
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-cd-deploy-workflow-'));
 	const outputFile = path.join(dir, 'output');

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -3,7 +3,31 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-function createGitHubApi(token, repo) {
+type GitHubApi = (apiPath: string, options?: RequestInit) => Promise<Response>;
+
+type GitHubDeployment = {
+	id: number;
+};
+
+type DeploymentArgs = {
+	token?: string;
+	repo?: string;
+	action?: string;
+	environment?: string;
+	ref?: string;
+	production?: string;
+	url?: string;
+	'deployment-id'?: string;
+	'skip-health-check'?: string;
+};
+
+function requireArg(args: DeploymentArgs, key: keyof DeploymentArgs): string {
+	const value = args[key];
+	if (!value) throw new Error(`Missing required arg: --${key}`);
+	return value;
+}
+
+function createGitHubApi(token: string, repo: string): GitHubApi {
 	const apiBase = `https://api.github.com/repos/${repo}`;
 	const headers = {
 		Authorization: `Bearer ${token}`,
@@ -12,17 +36,17 @@ function createGitHubApi(token, repo) {
 		'X-GitHub-Api-Version': '2022-11-28',
 	};
 
-	return async function githubApi(path, options = {}) {
-		const res = await fetch(`${apiBase}${path}`, { headers, ...options });
+	return async function githubApi(apiPath: string, options: RequestInit = {}) {
+		const res = await fetch(`${apiBase}${apiPath}`, { headers, ...options });
 		if (!res.ok) {
-			throw new Error(`GitHub API ${options.method || 'GET'} ${path}: ${res.status} ${await res.text()}`);
+			throw new Error(`GitHub API ${options.method || 'GET'} ${apiPath}: ${res.status} ${await res.text()}`);
 		}
 		return res;
 	};
 }
 
-async function requestDeployment(githubApi, args) {
-	const environment = args['environment'];
+async function requestDeployment(githubApi: GitHubApi, args: DeploymentArgs): Promise<void> {
+	const environment = requireArg(args, 'environment');
 	const ref = args['ref'] || 'main';
 	const production = args['production'] === 'true';
 	const res = await githubApi('/deployments', {
@@ -36,7 +60,7 @@ async function requestDeployment(githubApi, args) {
 			production_environment: production,
 		}),
 	});
-	const deployment = await res.json();
+	const deployment = (await res.json()) as GitHubDeployment;
 
 	await githubApi(`/deployments/${deployment.id}/statuses`, {
 		method: 'POST',
@@ -54,8 +78,8 @@ async function requestDeployment(githubApi, args) {
 	}
 }
 
-async function markDeploymentSuccess(githubApi, args) {
-	const environment = args['environment'];
+async function markDeploymentSuccess(githubApi: GitHubApi, args: DeploymentArgs): Promise<void> {
+	const environment = requireArg(args, 'environment');
 	const url = args['url'];
 	const deploymentId = args['deployment-id'];
 	const skipHealthCheck = args['skip-health-check'] === 'true';
@@ -99,10 +123,10 @@ async function markDeploymentSuccess(githubApi, args) {
 	console.log(`Deployment ${deploymentId} for ${environment} -> ${url}`);
 }
 
-async function cleanupDeployments(githubApi, args) {
-	const environment = args['environment'];
+async function cleanupDeployments(githubApi: GitHubApi, args: DeploymentArgs): Promise<void> {
+	const environment = requireArg(args, 'environment');
 	const res = await githubApi(`/deployments?environment=${encodeURIComponent(environment)}&per_page=100`);
-	const deployments = await res.json();
+	const deployments = (await res.json()) as GitHubDeployment[];
 
 	for (const deployment of deployments) {
 		await githubApi(`/deployments/${deployment.id}/statuses`, {
@@ -121,8 +145,8 @@ async function cleanupDeployments(githubApi, args) {
 	console.log(`Cleaned up ${deployments.length} deployment(s) for ${environment}`);
 }
 
-export async function main(argv = process.argv.slice(2)) {
-	const { values: args } = parseArgs({
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+	const { values } = parseArgs({
 		args: argv,
 		options: {
 			token: { type: 'string' },
@@ -136,11 +160,10 @@ export async function main(argv = process.argv.slice(2)) {
 			'skip-health-check': { type: 'string' },
 		},
 	});
-	for (const key of ['token', 'repo', 'action', 'environment']) {
-		if (!args[key]) throw new Error(`Missing required arg: --${key}`);
-	}
-	const action = args['action'];
-	const githubApi = createGitHubApi(args['token'], args['repo']);
+	const args = values as DeploymentArgs;
+	const action = requireArg(args, 'action');
+	const githubApi = createGitHubApi(requireArg(args, 'token'), requireArg(args, 'repo'));
+	requireArg(args, 'environment');
 
 	if (action === 'request') {
 		await requestDeployment(githubApi, args);

--- a/src/git-push.test.ts
+++ b/src/git-push.test.ts
@@ -5,11 +5,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { main } from './git-push.js';
+import { main } from './git-push.ts';
 
-const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'git-push.js');
+const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'git-push.ts');
 
-function writeFakeGit(binDir) {
+function writeFakeGit(binDir: string): void {
 	const gitPath = path.join(binDir, 'git');
 	fs.writeFileSync(
 		gitPath,
@@ -32,7 +32,7 @@ function writeFakeGit(binDir) {
 	fs.chmodSync(gitPath, 0o755);
 }
 
-function runGitPush(args, env = {}) {
+function runGitPush(args: string[], env: NodeJS.ProcessEnv = {}): string[][] {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-cd-deploy-workflow-'));
 	const binDir = path.join(dir, 'bin');
 	const logPath = path.join(dir, 'git.log');
@@ -58,7 +58,7 @@ function runGitPush(args, env = {}) {
 			.trim()
 			.split('\n')
 			.filter(Boolean)
-			.map((line) => JSON.parse(line));
+			.map((line) => JSON.parse(line) as string[]);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}

--- a/src/git-push.ts
+++ b/src/git-push.ts
@@ -3,8 +3,20 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-export async function main(argv = process.argv.slice(2)) {
-	const { values: args } = parseArgs({
+type GitPushArgs = {
+	message?: string;
+	paths?: string;
+	all?: boolean;
+};
+
+function requireArg(args: GitPushArgs, key: keyof GitPushArgs): string {
+	const value = args[key];
+	if (typeof value !== 'string' || !value) throw new Error(`Missing required arg: --${key}`);
+	return value;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+	const { values } = parseArgs({
 		args: argv,
 		options: {
 			message: { type: 'string' },
@@ -12,26 +24,25 @@ export async function main(argv = process.argv.slice(2)) {
 			all: { type: 'boolean' },
 		},
 	});
-	if (!args['message']) throw new Error('Missing required arg: --message');
-	function run(cmd, cmdArgs) {
+	const args = values as GitPushArgs;
+	const message = requireArg(args, 'message');
+	function run(cmd: string, cmdArgs: string[]): Buffer {
 		console.log(`$ ${cmd} ${cmdArgs.join(' ')}`);
 		return execFileSync(cmd, cmdArgs, { stdio: 'inherit' });
 	}
 
-	if (!args['paths'] && !args['all']) {
+	const paths = args.paths;
+	const all = args.all === true;
+	if (!paths && !all) {
 		throw new Error('Missing required arg: --paths or --all');
 	}
-
-	const message = args['message'];
-	const paths = args['paths'];
-	const all = args['all'] === true;
 
 	run('git', ['config', 'user.name', 'github-actions[bot]']);
 	run('git', ['config', 'user.email', 'github-actions[bot]@users.noreply.github.com']);
 
 	if (all) {
 		run('git', ['add', '-A']);
-	} else {
+	} else if (paths) {
 		try {
 			run('git', ['add', paths]);
 		} catch {

--- a/src/temp-cleanup.test.ts
+++ b/src/temp-cleanup.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { main } from './temp-cleanup.js';
+import { main } from './temp-cleanup.ts';
 
 describe('temp-cleanup', () => {
 	it('removes the matching temp stack', async () => {

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -3,19 +3,28 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-export async function main(argv = process.argv.slice(2)) {
-	const { values: args } = parseArgs({
+type TempCleanupArgs = {
+	'app-path'?: string;
+	'pr-number'?: string;
+};
+
+function requireArg(args: TempCleanupArgs, key: keyof TempCleanupArgs): string {
+	const value = args[key];
+	if (!value) throw new Error(`Missing required arg: --${key}`);
+	return value;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+	const { values } = parseArgs({
 		args: argv,
 		options: {
 			'app-path': { type: 'string' },
 			'pr-number': { type: 'string' },
 		},
 	});
-	for (const key of ['app-path', 'pr-number']) {
-		if (!args[key]) throw new Error(`Missing required arg: --${key}`);
-	}
-	const appPath = args['app-path'];
-	const prNumber = args['pr-number'];
+	const args = values as TempCleanupArgs;
+	const appPath = requireArg(args, 'app-path');
+	const prNumber = requireArg(args, 'pr-number');
 	const tempPath = `${appPath}-pr-${prNumber}`;
 
 	if (!fs.existsSync(tempPath)) {

--- a/src/temp-compose.test.ts
+++ b/src/temp-compose.test.ts
@@ -12,9 +12,10 @@ import {
 	dependsOnServices,
 	detectHost,
 	rewriteComposeForTempDeploy,
-} from './temp-compose.js';
+} from './temp-compose.ts';
+import type { ComposeDocument } from './temp-compose.ts';
 
-const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'temp-compose.js');
+const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'temp-compose.ts');
 
 describe('collectHosts', () => {
 	it('collects all unique hosts from labels', () => {
@@ -70,6 +71,7 @@ describe('detectHost', () => {
 			},
 		};
 		const host = detectHost(services);
+		assert.ok(host);
 		const domain = host.split('.').slice(1).join('.');
 		const hostname = `pr-148-close-powerlifting.${domain}`;
 		assert.strictEqual(hostname, 'pr-148-close-powerlifting.jaw.dev');
@@ -473,15 +475,15 @@ describe('temp-compose', () => {
 				'wajeht',
 			]);
 
-			const rewritten = yaml.load(fs.readFileSync(path.join(tempPath, 'docker-compose.yml'), 'utf8'));
+			const rewritten = yaml.load(fs.readFileSync(path.join(tempPath, 'docker-compose.yml'), 'utf8')) as ComposeDocument;
 
 			assert.deepStrictEqual(rewritten['x-docker-cd'], { rolling_update: false });
 			assert.deepStrictEqual(Object.keys(rewritten.services).sort(), ['demo', 'demo-db']);
 			assert.strictEqual(rewritten.services.demo.image, 'ghcr.io/wajeht/demo:abc1234');
 			assert.strictEqual(rewritten.services['demo-db'].container_name, undefined);
-			assert.deepStrictEqual(Object.keys(rewritten.networks).sort(), ['internal', 'traefik']);
-			assert.deepStrictEqual(Object.keys(rewritten.volumes), ['db']);
-			assert.strictEqual(rewritten.services.demo.labels[1], 'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)');
+			assert.deepStrictEqual(Object.keys(rewritten.networks!).sort(), ['internal', 'traefik']);
+			assert.deepStrictEqual(Object.keys(rewritten.volumes!), ['db']);
+			assert.strictEqual(rewritten.services.demo.labels![1], 'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)');
 			assert.strictEqual(fs.existsSync(path.join(tempPath, 'docker-cd.yml')), false);
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
@@ -527,7 +529,7 @@ describe('temp-compose', () => {
 				'oauth2-admin@file',
 			]);
 
-			const rewritten = yaml.load(fs.readFileSync(path.join(tempPath, 'docker-compose.yml'), 'utf8'));
+			const rewritten = yaml.load(fs.readFileSync(path.join(tempPath, 'docker-compose.yml'), 'utf8')) as ComposeDocument;
 
 			assert.deepStrictEqual(rewritten.services.demo.labels, [
 				'traefik.http.routers.demo-pr-42.rule=Host(`pr-42-demo.jaw.dev`)',

--- a/src/temp-compose.ts
+++ b/src/temp-compose.ts
@@ -4,8 +4,70 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import yaml from 'js-yaml';
 
-export function collectHosts(services) {
-	const allHosts = [];
+type ComposeVolumeObject = Record<string, unknown> & {
+	type?: unknown;
+	source?: unknown;
+};
+
+type ComposeVolume = string | ComposeVolumeObject | null;
+
+export type ComposeService = Record<string, unknown> & {
+	labels?: string[];
+	depends_on?: string[] | Record<string, unknown>;
+	networks?: string[] | Record<string, unknown>;
+	container_name?: unknown;
+	image?: string;
+	volumes?: ComposeVolume[];
+};
+
+export type ComposeDocument = Record<string, unknown> & {
+	services: Record<string, ComposeService>;
+	networks?: Record<string, unknown>;
+	volumes?: Record<string, unknown>;
+};
+
+type RewriteTempDeployOptions = {
+	appName: string;
+	serviceName: string;
+	tag: string;
+	prNumber: string;
+	repoOwner: string;
+	authMiddleware?: string;
+};
+
+type RewriteTempDeployResult = {
+	doc: ComposeDocument;
+	hostname: string;
+	url: string;
+	messages: string[];
+};
+
+type TempComposeArgs = {
+	'app-path'?: string;
+	'service-name'?: string;
+	tag?: string;
+	'pr-number'?: string;
+	'repo-owner'?: string;
+	'app-repo-path'?: string;
+	'auth-middleware'?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isComposeDocument(value: unknown): value is ComposeDocument {
+	return isObject(value) && isObject(value.services);
+}
+
+function requireArg(args: TempComposeArgs, key: keyof TempComposeArgs): string {
+	const value = args[key];
+	if (!value) throw new Error(`Missing required arg: --${key}`);
+	return value;
+}
+
+export function collectHosts(services: Record<string, ComposeService>): string[] {
+	const allHosts: string[] = [];
 	for (const [, service] of Object.entries(services)) {
 		if (!service.labels) continue;
 		for (const label of service.labels) {
@@ -17,12 +79,12 @@ export function collectHosts(services) {
 	return allHosts;
 }
 
-export function detectHost(services) {
+export function detectHost(services: Record<string, ComposeService>): string | null {
 	const allHosts = collectHosts(services);
 	return allHosts.find((h) => h.split('.').length >= 3 && !h.startsWith('www.')) || allHosts.find((h) => h.split('.').length >= 3) || allHosts[0] || null;
 }
 
-export function dependsOnServices(service) {
+export function dependsOnServices(service?: ComposeService): string[] {
 	const dependsOn = service?.depends_on;
 	if (Array.isArray(dependsOn)) {
 		return dependsOn.filter((name) => typeof name === 'string');
@@ -33,7 +95,7 @@ export function dependsOnServices(service) {
 	return [];
 }
 
-export function dependentServices(services, rootService) {
+export function dependentServices(services: Record<string, ComposeService> | undefined, rootService: string): Set<string> {
 	if (!services || !Object.hasOwn(services, rootService)) {
 		return new Set();
 	}
@@ -43,6 +105,7 @@ export function dependentServices(services, rootService) {
 
 	while (pending.length > 0) {
 		const serviceName = pending.pop();
+		if (!serviceName) continue;
 		for (const dependency of dependsOnServices(services[serviceName])) {
 			if (!Object.hasOwn(services, dependency) || selected.has(dependency)) {
 				continue;
@@ -55,7 +118,7 @@ export function dependentServices(services, rootService) {
 	return selected;
 }
 
-function serviceNetworkNames(service) {
+function serviceNetworkNames(service: ComposeService): string[] {
 	if (Array.isArray(service.networks)) {
 		return service.networks.filter((name) => typeof name === 'string');
 	}
@@ -65,7 +128,7 @@ function serviceNetworkNames(service) {
 	return [];
 }
 
-function namedVolumeFromString(volume) {
+function namedVolumeFromString(volume: string): string | null {
 	const [source] = volume.split(':');
 	if (!source || path.isAbsolute(source) || source.startsWith('.')) {
 		return null;
@@ -76,7 +139,7 @@ function namedVolumeFromString(volume) {
 	return source;
 }
 
-function pruneNetworks(doc, messages) {
+function pruneNetworks(doc: ComposeDocument, messages: string[]): void {
 	if (!doc.networks) return;
 
 	const usedNetworks = new Set();
@@ -98,7 +161,7 @@ function pruneNetworks(doc, messages) {
 	}
 }
 
-function pruneVolumes(doc, volumeNames, messages) {
+function pruneVolumes(doc: ComposeDocument, volumeNames: Set<string>, messages: string[]): void {
 	if (!doc.volumes) return;
 
 	for (const volumeName of Object.keys(doc.volumes)) {
@@ -113,7 +176,7 @@ function pruneVolumes(doc, volumeNames, messages) {
 	}
 }
 
-function applyAuthMiddleware(labels, authMiddleware) {
+function applyAuthMiddleware(labels: string[], authMiddleware?: string): string[] {
 	const middleware = authMiddleware?.trim();
 	if (!middleware) return labels;
 
@@ -142,20 +205,20 @@ function applyAuthMiddleware(labels, authMiddleware) {
 	return rewritten;
 }
 
-function tempTraefikName(name, serviceName, prNumber) {
+function tempTraefikName(name: string, serviceName: string, prNumber: string): string {
 	const tempName = `${serviceName}-pr-${prNumber}`;
 	if (name === serviceName) return tempName;
 	if (name.startsWith(`${serviceName}-`)) return `${tempName}${name.slice(serviceName.length)}`;
 	return `${name}-pr-${prNumber}`;
 }
 
-function rewriteTraefikLabel(label, serviceName, prNumber) {
+function rewriteTraefikLabel(label: string, serviceName: string, prNumber: string): string {
 	return label
-		.replace(/^traefik\.http\.routers\.([^.]+)\./, (_, name) => `traefik.http.routers.${tempTraefikName(name, serviceName, prNumber)}.`)
-		.replace(/^traefik\.http\.services\.([^.]+)\./, (_, name) => `traefik.http.services.${tempTraefikName(name, serviceName, prNumber)}.`);
+		.replace(/^traefik\.http\.routers\.([^.]+)\./, (_match, name: string) => `traefik.http.routers.${tempTraefikName(name, serviceName, prNumber)}.`)
+		.replace(/^traefik\.http\.services\.([^.]+)\./, (_match, name: string) => `traefik.http.services.${tempTraefikName(name, serviceName, prNumber)}.`);
 }
 
-export function rewriteComposeForTempDeploy(doc, options) {
+export function rewriteComposeForTempDeploy(doc: ComposeDocument, options: RewriteTempDeployOptions): RewriteTempDeployResult {
 	const { appName, serviceName, tag, prNumber, repoOwner, authMiddleware } = options;
 	const rewritten = structuredClone(doc);
 	const messages = [];
@@ -179,7 +242,7 @@ export function rewriteComposeForTempDeploy(doc, options) {
 
 	const domain = originalHost.split('.').slice(1).join('.');
 	const hostname = `pr-${prNumber}-${appName}.${domain}`;
-	const volumeNames = new Set();
+	const volumeNames = new Set<string>();
 
 	for (const service of Object.values(rewritten.services)) {
 		if (service.container_name) {
@@ -238,8 +301,8 @@ export function rewriteComposeForTempDeploy(doc, options) {
 	return { doc: rewritten, hostname, url: `https://${hostname}`, messages };
 }
 
-export async function main(argv = process.argv.slice(2)) {
-	const { values: args } = parseArgs({
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+	const { values } = parseArgs({
 		args: argv,
 		options: {
 			'app-path': { type: 'string' },
@@ -251,15 +314,13 @@ export async function main(argv = process.argv.slice(2)) {
 			'auth-middleware': { type: 'string' },
 		},
 	});
-	for (const key of ['app-path', 'service-name', 'tag', 'pr-number', 'repo-owner']) {
-		if (!args[key]) throw new Error(`Missing required arg: --${key}`);
-	}
+	const args = values as TempComposeArgs;
 	const appRepoPath = args['app-repo-path'];
-	const appPath = args['app-path'];
-	const serviceName = args['service-name'];
-	const tag = args['tag'];
-	const prNumber = args['pr-number'];
-	const repoOwner = args['repo-owner'];
+	const appPath = requireArg(args, 'app-path');
+	const serviceName = requireArg(args, 'service-name');
+	const tag = requireArg(args, 'tag');
+	const prNumber = requireArg(args, 'pr-number');
+	const repoOwner = requireArg(args, 'repo-owner');
 	const authMiddleware = args['auth-middleware'];
 	const appName = path.basename(appPath);
 	const tempPath = `${appPath}-pr-${prNumber}`;
@@ -277,6 +338,9 @@ export async function main(argv = process.argv.slice(2)) {
 
 	const composePath = path.join(tempPath, 'docker-compose.yml');
 	const doc = yaml.load(fs.readFileSync(composePath, 'utf8'));
+	if (!isComposeDocument(doc)) {
+		throw new Error('docker-compose.yml must contain a services block');
+	}
 	const result = rewriteComposeForTempDeploy(doc, { appName, serviceName, tag, prNumber, repoOwner, authMiddleware });
 	for (const message of result.messages) {
 		console.log(message);

--- a/src/update-tag.test.ts
+++ b/src/update-tag.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { imageRepository, updateComposeImageTag } from './update-tag.js';
+import { imageRepository, updateComposeImageTag } from './update-tag.ts';
 
 describe('imageRepository', () => {
 	it('removes tags and digests', () => {

--- a/src/update-tag.ts
+++ b/src/update-tag.ts
@@ -4,22 +4,65 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import yaml from 'js-yaml';
 
-function isObject(value) {
+type ComposeService = {
+	image?: unknown;
+};
+
+type ComposeDocument = {
+	services?: Record<string, ComposeService>;
+};
+
+type UpdateComposeImageTagOptions = {
+	serviceName: string;
+	repo: string;
+	tag: string;
+	digest: string;
+};
+
+type UpdateComposeImageTagResult =
+	| {
+			changed: true;
+			content: string;
+			image: string;
+			previousImage: string;
+	  }
+	| {
+			changed: false;
+			content: string;
+			image: string;
+			reason: string;
+	  };
+
+type UpdateTagArgs = {
+	'app-path'?: string;
+	'service-name'?: string;
+	tag?: string;
+	repo?: string;
+	digest?: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function escapeRegExp(value) {
+function requireArg(args: UpdateTagArgs, key: keyof UpdateTagArgs): string {
+	const value = args[key];
+	if (!value) throw new Error(`Missing required arg: --${key}`);
+	return value;
+}
+
+function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export function imageRepository(image) {
+export function imageRepository(image: string): string {
 	const withoutDigest = image.split('@')[0];
 	const lastSlash = withoutDigest.lastIndexOf('/');
 	const tagIndex = withoutDigest.indexOf(':', lastSlash + 1);
 	return tagIndex === -1 ? withoutDigest : withoutDigest.slice(0, tagIndex);
 }
 
-function replaceServiceImageLine(content, serviceName, image) {
+function replaceServiceImageLine(content: string, serviceName: string, image: string): string {
 	const lines = content.split('\n');
 	const servicesLine = lines.findIndex((line) => /^(\s*)services:\s*(?:#.*)?$/.test(line));
 	if (servicesLine === -1) {
@@ -63,8 +106,11 @@ function replaceServiceImageLine(content, serviceName, image) {
 	throw new Error(`Service "${serviceName}" must define an image`);
 }
 
-export function updateComposeImageTag(content, { serviceName, repo, tag, digest }) {
-	const doc = yaml.load(content);
+export function updateComposeImageTag(
+	content: string,
+	{ serviceName, repo, tag, digest }: UpdateComposeImageTagOptions,
+): UpdateComposeImageTagResult {
+	const doc = yaml.load(content) as ComposeDocument;
 	if (!isObject(doc) || !isObject(doc.services)) {
 		throw new Error('docker-compose.yml must contain a services block');
 	}
@@ -101,8 +147,8 @@ export function updateComposeImageTag(content, { serviceName, repo, tag, digest 
 	};
 }
 
-export async function main(argv = process.argv.slice(2)) {
-	const { values: args } = parseArgs({
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+	const { values } = parseArgs({
 		args: argv,
 		options: {
 			'app-path': { type: 'string' },
@@ -112,10 +158,12 @@ export async function main(argv = process.argv.slice(2)) {
 			digest: { type: 'string' },
 		},
 	});
-	for (const key of ['app-path', 'service-name', 'tag', 'repo', 'digest']) {
-		if (!args[key]) throw new Error(`Missing required arg: --${key}`);
-	}
-	const { 'app-path': appPath, 'service-name': serviceName, tag, repo, digest } = args;
+	const args = values as UpdateTagArgs;
+	const appPath = requireArg(args, 'app-path');
+	const serviceName = requireArg(args, 'service-name');
+	const tag = requireArg(args, 'tag');
+	const repo = requireArg(args, 'repo');
+	const digest = requireArg(args, 'digest');
 	const composePath = path.join(appPath, 'docker-compose.yml');
 	const content = fs.readFileSync(composePath, 'utf8');
 	const result = updateComposeImageTag(content, { serviceName, repo, tag, digest });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "noEmit": false,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true,
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- rename workflow scripts and tests from JS to TS
- add TypeScript configs, build/typecheck scripts, and ignored build artifacts
- update workflows and docs to reference TS scripts

## Verification
- npm run build
- npm test